### PR TITLE
Drop check requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,6 @@ AX_CODE_COVERAGE
 
 dnl Checks for programs.
 AC_PROG_CC
-PKG_CHECK_MODULES([CHECK], [check])
 
 dnl Checks for libraries.
 AC_CHECK_INCLUDES_DEFAULT


### PR DESCRIPTION
The configure script checks for the presence of the `check` program even though it doesn't appear to be used. The `testscript` script uses a bash function instead of an external program.